### PR TITLE
Reimplement "GlueLayer" in Objective-C to work around import-interop

### DIFF
--- a/Sources/GlueLayer/Dummy.m
+++ b/Sources/GlueLayer/Dummy.m
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+// Here just to get the package to compile in Xcode.
+//
+// Otherwise, we get:
+//
+// Build input file cannot be found: '/Users/gio/Developer/a8c/spm-abstraction-layer-demo/DerivedData/spm-abstraction-layer-demo/Build/Products/Debug/GlueLayer.o'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?

--- a/Sources/GlueLayer/Greeter.swift
+++ b/Sources/GlueLayer/Greeter.swift
@@ -1,6 +1,0 @@
-import Foundation
-
-@objc public protocol Greeter {
-
-    func sayHello() -> String
-}

--- a/Sources/GlueLayer/include/Greeter.h
+++ b/Sources/GlueLayer/include/Greeter.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@protocol Greeter
+
+- (NSString *)sayHello;
+
+@end


### PR DESCRIPTION
Before, in `36321d3e1bc80c0c211832d5a39300e18f50b3ea`

**Works with `swift build && swift test`**.

<img width="1248" alt="image" src="https://github.com/Automattic/spm-abstraction-layer-demo/assets/1218433/9c6592c6-5391-404b-af39-62cff5b81ba1">


**Fails in Xcode**, as per https://github.com/apple/swift-package-manager/issues/5951

<img width="1400" alt="image" src="https://github.com/Automattic/spm-abstraction-layer-demo/assets/1218433/21300f55-3ced-4c43-88db-c2ca44677888">

In this branch, `7ca2ab856ed82c9bd1531303faac214b39036dc0`

**Works with `swift build && swift test`** (no regression).

<img width="1232" alt="image" src="https://github.com/Automattic/spm-abstraction-layer-demo/assets/1218433/be59f4cc-34d3-4b9c-b38d-2534a914ef96">

**Also works in Xcode**

<img width="1391" alt="image" src="https://github.com/Automattic/spm-abstraction-layer-demo/assets/1218433/418b5bfa-30e0-46e5-8188-582068de987d">

---

Based on [the comment](https://github.com/apple/swift-package-manager/issues/5951#issuecomment-1340187793) in @crazytonyli 's issue, "Looks like in Xcode, there's no -fmodule-map-path being passed to MixCore.modulemap when building the "Mix" target," my guess is that by making all the Objective-C package dependencies Objective-C packages too, we bypass whatever limitation Xcode has in mixing the two languages at build time.